### PR TITLE
Simplify GitHub Pages copy

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -117,7 +117,7 @@ function problemResult(entityId, normalized, year, method, risk) {
 }
 
 function statusText(status) {
-  return { auto_matched: "自动接受", needs_confirmation: "需要确认", problem: "发现风险", unmatched: "未匹配" }[status] || status;
+  return { auto_matched: "已匹配", needs_confirmation: "候选结果", problem: "需核对", unmatched: "未匹配" }[status] || status;
 }
 
 function canonicalNameHistoryHtml(entityId) {
@@ -159,18 +159,18 @@ function countyEventsHtml(entityId) {
   if (!rows.length) return "";
   const visible = rows.slice(0, 12);
   const more = rows.length > visible.length ? `<p class="county-history-more">另有 ${rows.length - visible.length} 条记录，见仓库中的县级事件数据。</p>` : "";
-  return `<div class="county-history"><div class="county-history-head"><div class="section-label">县级变更记录</div><span>${rows.length} 条相关记录</span></div><p class="county-history-note">这里展示的是县级行政区划的事件记录，包括撤销、设立、合并、改隶、辖区调整和驻地变更；相关地级实体采用宽松文本命中，仅用于提示，不等同完整县级谱系。</p><div class="county-event-list">${visible.map((row) => `<article class="county-event"><div class="county-event-meta"><strong>${escapeHtml(row.year)}年</strong><span class="event-type">${escapeHtml(countyEventTypeText(row.event_type))}</span></div>${countyEventUnitsHtml(row)}<div class="county-event-change"><span>变更描述</span><p>${escapeHtml(row.change_description || row.description)}</p></div><div class="county-event-foot">${row.county_unit_types ? `涉及类型：${escapeHtml(row.county_unit_types)}` : "县级类型未从该行明确提取"}<a href="${escapeHtml(row.source_url)}" target="_blank" rel="noreferrer">Wikipedia 年度页 ↗</a></div></article>`).join("")}</div>${more}</div>`;
+  return `<div class="county-history"><div class="county-history-head"><div class="section-label">县级变更记录</div><span>${rows.length} 条相关记录</span></div><p class="county-history-note">记录包括撤销、设立、合并、改隶、辖区调整和驻地变更。地级关联按名称匹配，县级谱系请结合原始资料核对。</p><div class="county-event-list">${visible.map((row) => `<article class="county-event"><div class="county-event-meta"><strong>${escapeHtml(row.year)}年</strong><span class="event-type">${escapeHtml(countyEventTypeText(row.event_type))}</span></div>${countyEventUnitsHtml(row)}<div class="county-event-change"><span>变更描述</span><p>${escapeHtml(row.change_description || row.description)}</p></div><div class="county-event-foot">${row.county_unit_types ? `涉及类型：${escapeHtml(row.county_unit_types)}` : "类型未标注"}<a href="${escapeHtml(row.source_url)}" target="_blank" rel="noreferrer">Wikipedia 年度页 ↗</a></div></article>`).join("")}</div>${more}</div>`;
 }
 
 function resultHtml(result, name, year, province) {
   if (result.status === "unmatched") {
-    return `<div class="result-head"><div><div class="section-label">MATCH RESULT</div><h2>没有找到确定结果</h2></div><span class="status problem">未匹配</span></div><p class="result-note">“${escapeHtml(name)}”没有达到自动接受条件。可以补充年份、省份，或检查是否存在错别字。</p>`;
+    return `<div class="result-head"><div><div class="section-label">MATCH RESULT</div><h2>没有找到确定结果</h2></div><span class="status problem">未匹配</span></div><p class="result-note">可补充年份、省份，或检查名称。</p>`;
   }
   if (result.status === "needs_confirmation") {
-    return `<div class="result-head"><div><div class="section-label">MATCH RESULT</div><h2>${escapeHtml(name)}</h2></div><span class="status warn">需要确认</span></div><p class="result-note">工具找到候选，但没有足够证据自动替你决定。请结合原始资料和官方来源人工确认。</p><div class="candidate-list"><h3>候选实体</h3>${result.candidates.map((item) => `<div class="candidate"><span>${escapeHtml(item.entity.canonical_name_zh)} · ${escapeHtml(item.entityId)}</span><b>${item.score}%</b></div>`).join("")}</div>`;
+    return `<div class="result-head"><div><div class="section-label">MATCH RESULT</div><h2>${escapeHtml(name)}</h2></div><span class="status warn">候选结果</span></div><p class="result-note">当前有多个候选，请结合年份、省份和来源判断。</p><div class="candidate-list"><h3>候选实体</h3>${result.candidates.map((item) => `<div class="candidate"><span>${escapeHtml(item.entity.canonical_name_zh)} · ${escapeHtml(item.entityId)}</span><b>${item.score}%</b></div>`).join("")}</div>`;
   }
   const entity = result.entity;
-  const riskMessage = result.risk ? `需要注意：${escapeHtml(result.risk.replaceAll("|", "、"))}` : "全国唯一、年份有效且层级一致。可以作为自动匹配结果使用。";
+  const riskMessage = result.risk ? `状态：${escapeHtml(result.risk.replaceAll("|", "、"))}` : "名称、年份和层级匹配。";
   return `<div class="result-head"><div><div class="section-label">MATCH RESULT</div><h2>${escapeHtml(entity.canonical_name_zh || result.entityId)}</h2><p class="muted">${escapeHtml(result.entityId)} · ${escapeHtml(entity.province_name_zh)}</p></div><span class="status ${result.status === "problem" ? "problem" : "ok"}">${statusText(result.status)}</span></div><div class="result-grid"><div class="result-stat"><strong>${escapeHtml(result.entityId)}</strong><span>研究实体编号</span></div><div class="result-stat"><strong>${result.yearStatus === "not_checked" ? "未核验" : escapeHtml(result.yearStatus)}</strong><span>${year === null ? "年度状态" : `${year} 年状态`}</span></div><div class="result-stat"><strong>${Math.round(result.confidence * 100)}%</strong><span>匹配置信度</span></div></div><p class="result-note">${riskMessage}</p>${canonicalNameHistoryHtml(result.entityId)}${countyEventsHtml(result.entityId)}<p class="result-source">输入：${escapeHtml(name)} · 规范化：${escapeHtml(result.normalized)} · 方法：${escapeHtml(result.method)}${province ? ` · 省份：${escapeHtml(province)}` : ""}</p>`;
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="中国城市行政实体 Crosswalk：按名称、年份和省份进行保守、可解释的历史匹配。">
+    <meta name="description" content="查询中国城市历史名称、年度状态和行政区划变更。">
     <title>China Urban Crosswalk — 中国城市行政实体匹配</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%231f6e5a'/%3E%3Cpath d='M8 23V9h4v14H8Zm6 0V5h4v18h-4Zm6 0v-9h4v9h-4Z' fill='white'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="styles.css">
@@ -15,7 +15,7 @@
         <span>CHINA URBAN <b>CROSSWALK</b></span>
       </a>
       <div class="top-links">
-        <span id="version-pill" class="version-pill">V3.0</span>
+        <span id="version-pill" class="version-pill">V3.1.0</span>
         <a href="https://github.com/FIERsity/china-prefecture-crosswalk" target="_blank" rel="noreferrer">GitHub ↗</a>
       </div>
     </header>
@@ -24,8 +24,8 @@
       <section class="hero">
         <div>
           <p class="eyebrow">RESEARCH ENTITY CROSSWALK</p>
-          <h1>别只看城市名，<br><em>先确认它是哪一个实体。</em></h1>
-          <p class="hero-copy">把历史名称、年份和省份放在一起核验。结果保守、可解释；遇到合并、拆分或同名冲突时，工具会明确要求人工确认。</p>
+          <h1>中国城市行政区划沿革<br><em>按名称、年份和省份查询。</em></h1>
+          <p class="hero-copy">查询历史名称、年度状态和行政区划变更。</p>
         </div>
         <div class="hero-note"><span>363</span><small>跨期研究实体<br>1987—2026</small></div>
       </section>
@@ -40,8 +40,8 @@
         <div class="match-layout">
           <form id="match-form" class="card query-card">
             <div class="section-label">01 / MATCH ONE NAME</div>
-            <h2>输入一个历史或现代名称</h2>
-            <p class="muted">年份和省份不是必须的，但它们能帮助工具避免把同名实体混在一起。</p>
+            <h2>查询一个名称</h2>
+            <p class="muted">填写年份和省份，可缩小同名范围。</p>
 
             <label for="name-input">行政区名称</label>
             <input id="name-input" autocomplete="off" placeholder="例如：思茅市、徽州地区" required>
@@ -68,17 +68,17 @@
           <section id="match-result" class="card result-card" aria-live="polite">
             <div class="result-empty">
               <div class="result-symbol">↗</div>
-              <h2>结果会显示在这里</h2>
-              <p>先输入一个名称。工具只会自动接受全国唯一、年份有效且层级一致的结果。</p>
+              <h2>输入名称开始查询</h2>
+              <p>查询结果将在这里显示。</p>
             </div>
           </section>
         </div>
-        <p class="disclaimer">CNUR 是本项目的永久研究编号，不是民政部、国家统计局或任何年份的官方行政区划代码。高要求研究请同时核对官方批文和来源。</p>
+        <p class="disclaimer">CNUR 是本项目的研究编号。研究使用请核对官方批文和来源。</p>
       </section>
 
       <section id="events-view" class="view">
         <div class="card event-toolbar">
-          <div><div class="section-label">02 / TRACE CHANGE</div><h2>查看行政区划变更</h2><p class="muted">筛选改名、升格、合并和拆分事件；每条记录保留来源与审核状态。</p></div>
+          <div><div class="section-label">02 / TRACE CHANGE</div><h2>查看行政区划变更</h2><p class="muted">按年份和关键词查看改名、升格、合并、拆分等记录。</p></div>
           <div class="filter-row"><label>年份<select id="event-year"><option value="">全部</option></select></label><label>关键词<input id="event-keyword" placeholder="城市或省份"></label></div>
         </div>
         <div id="event-list" class="card table-card"></div>
@@ -86,13 +86,13 @@
 
       <section id="about-view" class="view">
         <div class="about-grid">
-          <article class="card about-card"><div class="section-label">03 / DATA NOTES</div><h2>这不是一张普通城市表</h2><p>项目把稳定研究实体、年度状态、行政区划事件和县级变更记录分开保存。查询单个城市时，页面会提示相关县级记录，但不会把宽松关联伪装成完整的县级谱系。</p><div class="stat-row"><div><strong>363</strong><span>研究实体</span></div><div><strong>14,520</strong><span>年度状态</span></div><div><strong>1,149</strong><span>县级记录</span></div></div></article>
-          <article class="card download-card"><div class="section-label">DOWNLOAD</div><h2>下载机器可读数据</h2><p class="muted">数据随 GitHub 提交自动构建，页面本身不需要 Python 服务。</p><a class="download-link" href="data/entities.csv" download>实体总表 CSV <span>↓</span></a><a class="download-link" href="data/entity_names_1987_2026.csv" download>历史名称区间 CSV <span>↓</span></a><a class="download-link" href="data/legal_roster_1987_2026.csv" download>年度状态 CSV <span>↓</span></a><a class="download-link" href="data/unified_events_1987_2026.csv" download>地级行政区划事件 CSV <span>↓</span></a><a class="download-link" href="data/county_administrative_events_1987_2026.csv" download>县级变更记录 CSV <span>↓</span></a></article>
+          <article class="card about-card"><div class="section-label">03 / DATA NOTES</div><h2>数据说明</h2><p>数据分为研究实体、年度状态、地级事件和县级变更记录。查询城市时，页面同时显示相关县级事件。</p><div class="stat-row"><div><strong>363</strong><span>研究实体</span></div><div><strong>14,520</strong><span>年度状态</span></div><div><strong>1,149</strong><span>县级记录</span></div></div></article>
+          <article class="card download-card"><div class="section-label">DOWNLOAD</div><h2>下载数据</h2><p class="muted">数据由 GitHub Actions 构建并发布到 GitHub Pages。</p><a class="download-link" href="data/entities.csv" download>实体总表 CSV <span>↓</span></a><a class="download-link" href="data/entity_names_1987_2026.csv" download>历史名称区间 CSV <span>↓</span></a><a class="download-link" href="data/legal_roster_1987_2026.csv" download>年度状态 CSV <span>↓</span></a><a class="download-link" href="data/unified_events_1987_2026.csv" download>地级行政区划事件 CSV <span>↓</span></a><a class="download-link" href="data/county_administrative_events_1987_2026.csv" download>县级变更记录 CSV <span>↓</span></a></article>
         </div>
-        <div class="card source-card"><strong>来源与限制</strong><span>当前主要二手信源为中文维基百科年度行政区划变更页面；部分事件同时记录国务院、民政部或地方政府批文号。请查看仓库中的 CODEBOOK、CHANGELOG 和 CITATION.cff。</span></div>
+        <div class="card source-card"><strong>来源与限制</strong><span>主要来源为中文维基百科年度行政区划变更页面，部分记录附有国务院、民政部或地方政府批文号。详见 CODEBOOK、CHANGELOG 和 CITATION.cff。</span></div>
       </section>
 
-      <footer class="footer"><span>RULE VERSION <b id="rule-version">2026.07.1</b></span><span>LOCAL-FIRST · EXPLAINABLE · RESEARCH USE</span></footer>
+      <footer class="footer"><span>RULE VERSION <b id="rule-version">2026.08.1</b></span><span>STATIC DATA · GITHUB PAGES · 1987—2026</span></footer>
     </main>
     <script src="app.js"></script>
   </body>


### PR DESCRIPTION
## What changed

- Shortened the homepage copy and removed contrast-heavy phrasing.
- Replaced the marketing-style hero text with a direct description of the tool.
- Simplified query instructions, empty states, match statuses, risk messages, and county-event notes.
- Updated the fallback page version and rule version to V3.1.0 / 2026.08.1.

## Validation

- `python3 scripts/validate_data.py`
- `node --check docs/app.js`
- `git diff --check`
- `pytest -q` — 15 passed
